### PR TITLE
Fixed non-BSS data allocation

### DIFF
--- a/src/boot.asm
+++ b/src/boot.asm
@@ -14,7 +14,7 @@ align 4
 	dd	FLAGS
 	dd	CHECKSUM
 
-section .stack, nx		; A stack (We need one, otherwise the C won't work :( )!
+section .bss			; A stack (We need one, otherwise the C won't work :( )!
 align 4				; We might eventually want a bigger stack.
 stack_bottom:
 resb 8192


### PR DESCRIPTION
Without calling the stack section `.bss` it doesn't compile for me. This is what [NASM docs](http://www.nasm.us/doc/nasmdoc3.html#section-3.2.2) are saying: "RESB, RESW, ... and RESZ are designed to be used in the BSS section of a module".

